### PR TITLE
Properly apply leave-to-class

### DIFF
--- a/src/VTNotification.vue
+++ b/src/VTNotification.vue
@@ -38,7 +38,7 @@ export default {
         'enter-to-class': this.transitionGroupClasses.enterToClass,
         'leave-active-class': this.transitionGroupClasses.leaveActiveClass,
         'leave-from-class': this.transitionGroupClasses.leaveFromClass,
-        'leave-to': this.transitionGroupClasses.leaveToClass,
+        'leave-to-class': this.transitionGroupClasses.leaveToClass,
         'move-class': this.transitionGroupClasses.moveClass,
       },
       [


### PR DESCRIPTION
After a little digging the fix to that warning I found in #2 is pretty simple. Still stumped about the whole slots warning though...